### PR TITLE
fs/proc: Hide lineage paths and fake zygote cache flags

### DIFF
--- a/fs/proc/base.c
+++ b/fs/proc/base.c
@@ -2289,10 +2289,16 @@ static int map_files_get_link(struct dentry *dentry, struct path *path)
 
 	rc = -ENOENT;
 	vma = find_exact_vma(mm, vm_start, vm_end);
-	if (vma && vma->vm_file) {
-		*path = vma->vm_file->f_path;
-		path_get(path);
-		rc = 0;
+	if (vma) {
+		if (vma->vm_file) {
+			if (strstr(vma->vm_file->f_path.dentry->d_name.name, "lineage")) {
+				rc = kern_path("/system/framework/framework-res.apk", LOOKUP_FOLLOW, path);
+			} else {
+				*path = vma->vm_file->f_path;
+				path_get(path);
+				rc = 0;
+			}
+		}
 	}
 	up_read(&mm->mmap_sem);
 

--- a/fs/proc/task_mmu.c
+++ b/fs/proc/task_mmu.c
@@ -496,6 +496,23 @@ static int show_vma_header_prefix(struct seq_file *m, unsigned long start,
 	return 0;
 }
 
+static void show_vma_header_prefix_fake(struct seq_file *m,
+				   unsigned long start, unsigned long end,
+				   vm_flags_t flags, unsigned long long pgoff,
+				   dev_t dev, unsigned long ino)
+{
+	seq_setwidth(m, 25 + sizeof(void *) * 6 - 1);
+	seq_printf(m, "%08lx-%08lx %c%c%c%c %08llx %02x:%02x %lu ",
+		   start,
+		   end,
+		   flags & VM_READ ? 'r' : '-',
+		   flags & VM_WRITE ? 'w' : '-',
+		   flags & VM_EXEC ? '-' : '-',
+		   flags & VM_MAYSHARE ? 's' : 'p',
+		   pgoff,
+		   MAJOR(dev), MINOR(dev), ino);
+}
+
 static void
 show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
 {
@@ -510,9 +527,28 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
 
 	if (file) {
 		struct inode *inode = file_inode(vma->vm_file);
+		struct dentry *dentry = file->f_path.dentry;
 		dev = inode->i_sb->s_dev;
 		ino = inode->i_ino;
 		pgoff = ((loff_t)vma->vm_pgoff) << PAGE_SHIFT;
+
+		if (dentry) {
+			const char *path = (const char *)dentry->d_name.name;
+			if (strstr(path, "lineage")) {
+				start = vma->vm_start;
+				end = vma->vm_end;
+				show_vma_header_prefix_fake(m, start, end, flags, pgoff, dev, ino);
+				name = "/system/framework/framework-res.apk";
+				goto done;
+			}
+
+			if (strstr(path, "jit-zygote-cache")) {
+				start = vma->vm_start;
+				end = vma->vm_end;
+				show_vma_header_prefix_fake(m, start, end, flags, pgoff, dev, ino);
+				goto bypass;
+			}
+		}
 	}
 
 	start = vma->vm_start;
@@ -520,6 +556,7 @@ show_map_vma(struct seq_file *m, struct vm_area_struct *vma)
 	if (show_vma_header_prefix(m, start, end, flags, pgoff, dev, ino))
 		return;
 
+bypass:
 	/*
 	 * Print the dentry name for named mappings, and a
 	 * special [heap] marker for the heap:


### PR DESCRIPTION
* Dont allow paths with lineage to be listed
* Fake all lineage
* Fake all lineage symlinks
* Fake jit-zygote-cache flags backslashxx <118538522+backslashxx@users.noreply.github.com>